### PR TITLE
Added a demo stage for certificate pinning. Fixed some bugs.

### DIFF
--- a/app/android/kotlin/ShipFast/app/build.gradle
+++ b/app/android/kotlin/ShipFast/app/build.gradle
@@ -34,9 +34,14 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Required by the Auth0 Android Manifest
-        manifestPlaceholders = [auth0Domain: "$System.env.AUTH0_DOMAIN", auth0Scheme: "$System.env.AUTH0_SCHEME"]
+        manifestPlaceholders = [
+          auth0Domain: "$System.env.AUTH0_DOMAIN",
+          auth0Scheme: "$System.env.AUTH0_SCHEME",
+          ANDROID_GEO_API_KEY: "$System.env.ANDROID_GEO_API_KEY",
+        ]
 
         resValue "string", "app_name", "ShipFast"
+        resValue "string", "app_launcher_icon_name", "ShipFast"
         resValue "string", "APPROOV_INITIAL_CONFIG", ""
         resValue "string", "ANDROID_GEO_API_KEY", "$System.env.ANDROID_GEO_API_KEY"
         resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#aaaaaa"
@@ -72,7 +77,7 @@ android {
             applicationIdSuffix ".api_key"
             versionNameSuffix "-api_key"
             buildConfigField "String", "DEMO_STAGE", "\"API_KEY_PROTECTION\""
-            resValue "string", "app_name", "SF-API-Key"
+            resValue "string", "app_launcher_icon_name", "SF-API-Key"
             resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#3f51b5"
             resValue "color", "DEMO_STAGE_PRIMARY_DARK_COLOR", "#303f9f"
         }
@@ -82,7 +87,7 @@ android {
             applicationIdSuffix ".static_hmac"
             versionNameSuffix "-static_hmac"
             buildConfigField "String", "DEMO_STAGE", "\"HMAC_STATIC_SECRET_PROTECTION\""
-            resValue "string", "app_name", "SF-SHMAC"
+            resValue "string", "app_launcher_icon_name", "SF-SHMAC"
             resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#ec971f"
             resValue "color", "DEMO_STAGE_PRIMARY_DARK_COLOR", "#d58512"
         }
@@ -92,9 +97,19 @@ android {
             applicationIdSuffix ".dynamic_hmac"
             versionNameSuffix "-dynamic_hmac"
             buildConfigField "String", "DEMO_STAGE", "\"HMAC_DYNAMIC_SECRET_PROTECTION\""
-            resValue "string", "app_name", "SF-DHMAC"
+            resValue "string", "app_launcher_icon_name", "SF-DHMAC"
             resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#d9534f"
             resValue "color", "DEMO_STAGE_PRIMARY_DARK_COLOR", "#d43f3a"
+        }
+
+        certificate_pinning {
+            dimension "demo_stages"
+            applicationIdSuffix ".certificate_pinning"
+            versionNameSuffix "-certificate_pinning"
+            buildConfigField "String", "DEMO_STAGE", "\"CERTIFICATE_PINNING_PROTECTION\""
+            resValue "string", "app_launcher_icon_name", "SF-Pinning"
+            resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#868646"
+            resValue "color", "DEMO_STAGE_PRIMARY_DARK_COLOR", "#646435"
         }
 
         approov {
@@ -102,7 +117,7 @@ android {
             applicationIdSuffix ".approov"
             versionNameSuffix "-approov"
             buildConfigField "String", "DEMO_STAGE", "\"APPROOV_APP_AUTH_PROTECTION\""
-            resValue "string", "app_name", "SF-Approov"
+            resValue "string", "app_launcher_icon_name", "SF-Approov"
             resValue "color", "DEMO_STAGE_PRIMARY_COLOR", "#449d44"
             resValue "color", "DEMO_STAGE_PRIMARY_DARK_COLOR", "#398439"
             resValue "string", "APPROOV_INITIAL_CONFIG", "$System.env.APPROOV_INITIAL_CONFIG"

--- a/app/android/kotlin/ShipFast/app/src/certificate_pinning/AndroidManifest.xml
+++ b/app/android/kotlin/ShipFast/app/src/certificate_pinning/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.criticalblue.shipfast">
+    <application android:networkSecurityConfig="@xml/network_security_config">
+    </application>
+</manifest>

--- a/app/android/kotlin/ShipFast/app/src/main/AndroidManifest.xml
+++ b/app/android/kotlin/ShipFast/app/src/main/AndroidManifest.xml
@@ -6,10 +6,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
-    <!-- MITMPROXY: ALLOW SELF SIGNED CERTIFICATE -->
-    <!-- Uncomment and move the next line to right after <application -->
-    <!-- android:networkSecurityConfig="@xml/network_security_config"-->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -25,7 +23,7 @@
             android:required="false" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/ANDROID_GEO_API_KEY" />
+            android:value="${ANDROID_GEO_API_KEY}" />
 
         <meta-data
             android:name="com.criticalblue.shipfast.auth0Domain"
@@ -35,10 +33,11 @@
             android:name="com.criticalblue.shipfast.auth0Scheme"
             android:value="${auth0Scheme}" />
 
-        <activity android:name="com.criticalblue.shipfast.LoginActivity">
+        <activity
+          android:name="com.criticalblue.shipfast.LoginActivity"
+          android:label="@string/app_launcher_icon_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/BaseActivity.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/BaseActivity.kt
@@ -29,6 +29,10 @@ open class BaseActivity: AppCompatActivity() {
                 primary_color = "#d9534f"
                 primary_dark_color = "#d43f3a"
             }
+            DemoStage.CERTIFICATE_PINNING_PROTECTION -> {
+              primary_color = "#868646"
+              primary_dark_color = "#646435"
+            }
             DemoStage.APPROOV_APP_AUTH_PROTECTION -> {
                 primary_color = "#449d44"
                 primary_dark_color = "#398439"

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/LoginActivity.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/LoginActivity.kt
@@ -35,6 +35,8 @@ import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.provider.AuthCallback
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
+import com.criticalblue.shipfast.config.API_BASE_URL
+import com.criticalblue.shipfast.config.HOME_SCREEN_TITLE
 import com.criticalblue.shipfast.config.JniEnv
 import com.criticalblue.shipfast.user.saveUserCredentials
 
@@ -57,6 +59,8 @@ class LoginActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_login)
+        supportActionBar?.title = HOME_SCREEN_TITLE
+        supportActionBar?.subtitle = "URL: $API_BASE_URL"
 
         // Add an 'on-click' listener to the user login button
         loginButton = findViewById(R.id.loginButton)

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/ShipFastApp.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/ShipFastApp.kt
@@ -16,16 +16,21 @@ class ShipFastApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // *** APPROOV IMPLEMENTATION ***
-        // Initializes the Approov SDK with the Approov initial configuration
-        // @link https://approov.io/docs/latest/approov-usage-documentation/#sdk-configuration
-        approovService = ApproovService(applicationContext, resources.getString(R.string.approov_config))
+        when (CURRENT_DEMO_STAGE) {
+            DemoStage.APPROOV_APP_AUTH_PROTECTION -> {
 
-        // *** APPROOV IMPLEMENTATION ***
-        // Enables the Approov token binding advanced feature, by binding the
-        // Approov token with the Authorization token header.
-        // @link https://approov.io/docs/latest/approov-usage-documentation/#token-binding
-        approovService!!.setBindingHeader("Authorization")
+              // *** APPROOV IMPLEMENTATION ***
+              // Initializes the Approov SDK with the Approov initial configuration
+              // @link https://approov.io/docs/latest/approov-usage-documentation/#sdk-configuration
+              approovService = ApproovService(applicationContext, resources.getString(R.string.approov_config))
+
+              // *** APPROOV IMPLEMENTATION ***
+              // Enables the Approov token binding advanced feature, by binding the
+              // Approov token with the Authorization token header.
+              // @link https://approov.io/docs/latest/approov-usage-documentation/#token-binding
+              approovService!!.setBindingHeader("Authorization")
+            }
+        }
 
         Log.d(TAG, "Created The ShipFastApp")
     }

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/ShipmentActivity.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/ShipmentActivity.kt
@@ -21,15 +21,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package com.criticalblue.shipfast
 
-
 import android.content.pm.PackageManager
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.core.app.ActivityCompat
 import android.Manifest
 import android.content.Intent
 import android.graphics.Color
 import android.location.Location
+import android.location.LocationManager
 import android.util.Log
 import android.view.View
 import android.widget.*
@@ -185,7 +184,14 @@ class ShipmentActivity : BaseActivity(), OnMapReadyCallback {
     private fun getDeviceLocation(attempts: Int = 0) {
 
         if(attempts > 5) {
-            Log.w(TAG, "Giving up of trying to get the last known location, after 5 attempts.")
+            Log.w(TAG, "Not able to fetch the last known location after 5 attempts. The default location for the Google Headquarters in US will be used.")
+            lastKnownLocation = Location(LocationManager.NETWORK_PROVIDER) // OR GPS_PROVIDER based on the requirement
+            // Emulator default coordinates - Google Headquarters in US
+            lastKnownLocation!!.latitude = 37.4220353
+            lastKnownLocation!!.longitude = -122.0839885
+
+            this.addCurrentLocationToMap(lastKnownLocation!!.latitude, lastKnownLocation!!.longitude)
+
             return
         }
 
@@ -207,13 +213,13 @@ class ShipmentActivity : BaseActivity(), OnMapReadyCallback {
                             this.addCurrentLocationToMap(lastKnownLocation!!.latitude, lastKnownLocation!!.longitude)
                         } else {
                             Log.i(TAG, "Failed to get the last known location. Retrying...")
-                            this.getDeviceLocation(attempts)
+                            this.getDeviceLocation(attempts + 1)
                         }
 
                     } else {
                         Log.e(TAG, "Exception: %s", task.exception)
                         Log.i(TAG, "An error occurred while trying to get the last location. Retrying...")
-                        this.getDeviceLocation(attempts)
+                        this.getDeviceLocation(attempts + 1)
                     }
                 }
             }
@@ -230,7 +236,6 @@ class ShipmentActivity : BaseActivity(), OnMapReadyCallback {
                         .position(LatLng(latitude, longitude))
                         .title("Driver Coordinates: ${latitude}, ${longitude}")
                         .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
-
         )
 
         this.map?.moveCamera(CameraUpdateFactory.newLatLngZoom(

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/api/RestAPI.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/api/RestAPI.kt
@@ -244,7 +244,7 @@ object RestAPI {
 
         // Configure the request HMAC based on the demo stage
         when (CURRENT_DEMO_STAGE) {
-            DemoStage.API_KEY_PROTECTION, DemoStage.APPROOV_APP_AUTH_PROTECTION -> {
+            DemoStage.API_KEY_PROTECTION, DemoStage.APPROOV_APP_AUTH_PROTECTION, DemoStage.CERTIFICATE_PINNING_PROTECTION -> {
                 throw IllegalStateException("calculateAPIRequestHMAC() not used in this demo stage")
             }
             DemoStage.HMAC_STATIC_SECRET_PROTECTION -> {

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/config/DemoConfiguration.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/config/DemoConfiguration.kt
@@ -34,6 +34,8 @@ enum class DemoStage {
     HMAC_STATIC_SECRET_PROTECTION,
     /** The demo which introduces API request signing by HMAC using a dynamic secret in code */
     HMAC_DYNAMIC_SECRET_PROTECTION,
+    /** The demo stage where certificate pinning is implemented through the network security config file **/
+    CERTIFICATE_PINNING_PROTECTION,
     /** The demo which uses CriticalBlue Approov protection by authenticating the app */
     APPROOV_APP_AUTH_PROTECTION
 }
@@ -42,6 +44,7 @@ object ApiUrl {
     fun build(): String {
         val api_version = when (BuildConfig.DEMO_STAGE) {
             "API_KEY_PROTECTION" -> "v1"
+            "CERTIFICATE_PINNING_PROTECTION" -> "v1"
             "HMAC_STATIC_SECRET_PROTECTION" -> "v2"
             "HMAC_DYNAMIC_SECRET_PROTECTION" -> "v3"
             "APPROOV_APP_AUTH_PROTECTION" -> "v4"
@@ -52,12 +55,26 @@ object ApiUrl {
     }
 }
 
+object HomeScreenTitle {
+    fun build(): String {
+        return when (BuildConfig.DEMO_STAGE) {
+            "API_KEY_PROTECTION" -> "DEMO STAGE: Api Key"
+            "CERTIFICATE_PINNING_PROTECTION" -> "DEMO STAGE: Certificate Pinning"
+            "HMAC_STATIC_SECRET_PROTECTION" -> "DEMO STAGE: Static HMAC"
+            "HMAC_DYNAMIC_SECRET_PROTECTION" -> "DEMO STAGE: Dynamic HMAC"
+            "APPROOV_APP_AUTH_PROTECTION" -> "DEMO STAGE: Approov Threat Protection"
+            else -> ""
+        }
+    }
+}
+
 /** The current demo stage */
 val CURRENT_DEMO_STAGE = DemoStage.valueOf(BuildConfig.DEMO_STAGE)
 
 /** The ShipFast server's base URL */
-//const val API_BASE_URL = "http://10.0.2.2:3333"
 val API_BASE_URL = ApiUrl.build()
+
+val HOME_SCREEN_TITLE = HomeScreenTitle.build()
 
 /** The maximum number of attempts to try to make an API request before reporting a failure */
 const val API_REQUEST_ATTEMPTS = 3

--- a/app/android/kotlin/ShipFast/app/src/main/res/xml/network_security_config.xml
+++ b/app/android/kotlin/ShipFast/app/src/main/res/xml/network_security_config.xml
@@ -3,12 +3,18 @@
 <!-- Official Android N API -->
 <!--https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html-->
 <network-security-config>
-    <base-config>
+    <domain-config>
+      <base-config>
         <trust-anchors>
-            <!-- Trust preinstalled CAs -->
-            <certificates src="system" />
-            <!-- Additionally trust user added CAs -->
-            <certificates src="user" />
+          <certificates src="system"/>
         </trust-anchors>
-    </base-config>
+      </base-config>
+
+      <domain includeSubdomains="true">shipfast.demo.approov.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">NHnhk73iktV22yFicZC844iGk+LH5X3yRrC6ZTZJ80w=</pin>
+            <!-- In production is strongly advised to use a backup pin, unless you are using the Approov dynamic certificate pinning -->
+            <!--<pin digest="SHA-256">fwza0LRMXouZHRC8Ei+4PyuldPDcf3UKgO/04cDM1oE=</pin>-->
+        </pin-set>
+    </domain-config>
 </network-security-config>

--- a/app/android/kotlin/ShipFast/bin/apk-cli.sh
+++ b/app/android/kotlin/ShipFast/bin/apk-cli.sh
@@ -73,11 +73,12 @@ Clean_Cache() {
   rm -rf \
     ~/.gradle/caches \
     "${app_dir}"/.gradle \
+    "${app_dir}"/build \
+    "${app_dir}"/approov/build \
     "${app_dir}"/app/.externalNativeBuild \
     "${app_dir}"/app/android \
     "${app_dir}"/app/build \
-    "${app_dir}"/app/.cxx \
-    "${app_dir}"/approov/build
+    "${app_dir}"/app/.cxx
 }
 
 Gradle_Run() {

--- a/bin/java-shell.sh
+++ b/bin/java-shell.sh
@@ -29,6 +29,7 @@ install           Installs the APK for a product flavor via USB in the given mob
                   $ ./apk install Samsung api_key
                   $ ./apk install Samsung static_hmac
                   $ ./apk install Samsung dynamic_hmac
+                  $ ./apk install Samsung certificate_pinning
                   $ ./apk install Samsung approov
 
 list-usb          List all USB devices
@@ -140,7 +141,7 @@ Gradle() {
 }
 
 List_Usb() {
-  local _result=$(lsusb | grep -i "${device_brand}" -)
+  local _result="$(lsusb | grep -i "${device_brand}" -)"
 
   if [ -z "${_result}" ]; then
     printf "\nNo devices found. His your device connected to the usb port?\n\n"

--- a/shipfast
+++ b/shipfast
@@ -211,6 +211,8 @@ Main() {
         exit 1
     fi
 
+    mkdir -p "${PROJECT_HOST_DIR}"
+
     local APPROOV_SDK_PATH=./app/android/kotlin/ShipFast/approov/approov.aar
 
     # Setup X11 server authentication


### PR DESCRIPTION
* Certificate pinning implemented through the network security config file.
    + this only applies to the demo stage for certificate pinning.
    + the new demo stage will not be incorporated in the current demo stages flow.
    + the new demo stage main proposal is to support the new Frida blog post.
* The @app_name string value is now the same across all demo stages:
    + previously was renamed in a per build flavour basis to have a different title for the app launcher icon.
    + the app launcher icon has now a dedicated string value for this propose.
    + all usages of the @app_name string value are now consistent in all demo stages, like when asking for location permisssions.
* The Action bar on the top of the home screen shows now the demo stage and the API url being used to allow for more transparent demo.
* App Bugs:
    + fixed last known location being null in the first launch on a brand new emulator.
    + only initiate the Approov service when in the Approov demo stage
* Stack Bugs:
    + fixed listing usd devices with whitespaces in the name
    + fixed missing directory when starting the project from scratch

Signed-off-by: Exadra37 <exadra37@gmail.com>