### PR TITLE
Improved support for the Approov SDK. Improved the network security config. Fixed and improved the apk bash script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ apis.json
 avd/
 .cxx/
 .transforms/
+initial-config.*

--- a/app/android/kotlin/ShipFast/app/src/certificate_pinning/res/xml/network_security_config.xml
+++ b/app/android/kotlin/ShipFast/app/src/certificate_pinning/res/xml/network_security_config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Official Android N API -->
+<!--https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html-->
+<!-- This file is only used when enabled in the Manifest for this build flavour -->
+<network-security-config>
+    <domain-config>
+      <!--<base-config>-->
+        <!-- Will apply to all domains that don't have a dedicated configuration to set their pins -->
+        <!-- The below configuration is the default behaviour when a network security config file is used -->
+        <!--<trust-anchors>-->
+          <!-- Configures the mobile app to only trust in certificates already present in the operating system trusted store -->
+          <!-- Any certificate added by the user will not be trusted, because they will be saved into the user trusted store -->
+          <!--<certificates src="system"/>-->
+        <!--</trust-anchors>-->
+      <!--</base-config>-->
+
+      <domain includeSubdomains="true">shipfast.demo.approov.io</domain>
+        <!-- Configures the mobile app to use certificate pinning for this domain -->
+        <!-- The mobile app will not trust in certificates from the system or user trusted store, unless explicitly configured below in <trust-anchors> -->
+        <pin-set>
+            <pin digest="SHA-256">NHnhk73iktV22yFicZC844iGk+LH5X3yRrC6ZTZJ80w=</pin>
+            <!-- In production is strongly advised to use a backup pin, unless you are using the Approov dynamic certificate pinning -->
+            <!--<pin digest="SHA-256">fwza0LRMXouZHRC8Ei+4PyuldPDcf3UKgO/04cDM1oE=</pin>-->
+        </pin-set>
+
+        <!-- MITMPROXY: ALLOW SELF SIGNED CERTIFICATE -->
+        <!-- Uncomment the trust anchors configuration to allow for the proxy custom certificate to be trusted in the TLS handshake -->
+        <!-- Bear in mind that to bypass pinning you also need to comment out the entire <pin-set> section above -->
+        <!--<trust-anchors>-->
+          <!-- The user will need to add the proxy certificate to the user trusted store on the device. -->
+          <!-- <certificates src="user"/> -->
+        <!--</trust-anchors>-->
+    </domain-config>
+</network-security-config>

--- a/app/android/kotlin/ShipFast/app/src/main/AndroidManifest.xml
+++ b/app/android/kotlin/ShipFast/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/dto/Shipment.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/com/criticalblue/shipfast/dto/Shipment.kt
@@ -111,7 +111,7 @@ class ShipmentsResponse (
             this.errorMessage = "Transient Error: Certificate pinning mismatch!"
             this.hasTransientError = true
         } catch (e: Throwable) {
-            this.errorMessage = exception.message ?: this.errorMessage
+            this.errorMessage = "Exception: " + (exception.message ?: this.errorMessage)
             this.hasFatalError = true
         }
     }
@@ -254,7 +254,7 @@ class ShipmentResponse (
             this.errorMessage = "Transient Error: Certificate pinning mismatch!"
             this.hasTransientError = true
         } catch (e: Throwable) {
-            this.errorMessage = exception.message ?: this.errorMessage
+            this.errorMessage = "Exception: " + (exception.message ?: this.errorMessage)
             this.hasFatalError = true
         }
     }

--- a/app/android/kotlin/ShipFast/app/src/main/java/io/approov/framework/okhttp/ApproovService.kt
+++ b/app/android/kotlin/ShipFast/app/src/main/java/io/approov/framework/okhttp/ApproovService.kt
@@ -1,7 +1,7 @@
 // ApproovService framework for integrating Approov into apps using OkHttp.
 //
 // MIT License
-// 
+//
 // Copyright (c) 2016-present, Critical Blue Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
@@ -10,7 +10,7 @@
 // subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
 // ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
@@ -18,17 +18,15 @@
 
 package io.approov.framework.okhttp
 
-import android.util.Log
 import android.content.Context
-
+import android.util.Log
 import com.criticalblue.approovsdk.Approov
-
-import java.io.IOException
-
 import okhttp3.CertificatePinner
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import java.io.IOException
+
 
 // ApproovService provides a mediation layer to the Approov SDK itself
 class ApproovService
@@ -165,10 +163,9 @@ class ApproovService
             if (initialized) {
                 // build the pinning configuration
                 var pinBuilder = CertificatePinner.Builder()
-                val pins = Approov.getPins("public-key-sha256")
-                for (entry in pins.entries) {
-                    for (pin in entry.value)
-                        pinBuilder = pinBuilder.add(entry.key, "sha256/$pin")
+                val pins: Map<String?, List<String>?> = Approov.getPins("public-key-sha256") as Map<String?, List<String>?>
+                for ((key, value) in pins) {
+                  for (pin in value!!) pinBuilder = pinBuilder.add(key!!, "sha256/$pin")
                 }
 
                 // remove any existing ApproovTokenInterceptor from the builder

--- a/app/android/kotlin/ShipFast/app/src/main/res/xml/network_security_config.xml
+++ b/app/android/kotlin/ShipFast/app/src/main/res/xml/network_security_config.xml
@@ -2,19 +2,18 @@
 
 <!-- Official Android N API -->
 <!--https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html-->
+<!-- This file is only used when enabled in the default Manifest-->
 <network-security-config>
-    <domain-config>
-      <base-config>
-        <trust-anchors>
-          <certificates src="system"/>
-        </trust-anchors>
-      </base-config>
+  <base-config>
+    <trust-anchors>
+      <!-- Configures the mobile app to only trust in certificates already present in the operating system trusted store -->
+      <!-- Any certificate added by the user will not be trusted, because they will be saved into the user trusted store -->
+      <certificates src="system"/>
 
-      <domain includeSubdomains="true">shipfast.demo.approov.io</domain>
-        <pin-set>
-            <pin digest="SHA-256">NHnhk73iktV22yFicZC844iGk+LH5X3yRrC6ZTZJ80w=</pin>
-            <!-- In production is strongly advised to use a backup pin, unless you are using the Approov dynamic certificate pinning -->
-            <!--<pin digest="SHA-256">fwza0LRMXouZHRC8Ei+4PyuldPDcf3UKgO/04cDM1oE=</pin>-->
-        </pin-set>
-    </domain-config>
+      <!-- MITMPROXY: ALLOW SELF SIGNED CERTIFICATE -->
+      <!-- The user will need to add the proxy certificate to the user trusted store on the device. -->
+      <!-- Uncomment below line to allow for the proxy custom certificate to be trusted. -->
+      <!--<certificates src="user"/>-->
+    </trust-anchors>
+  </base-config>
 </network-security-config>


### PR DESCRIPTION
* Updated the Approov Service to support the latest Approov Sdk(2.6) when setting the pins.
* Used a separated network security config file for the certificate pinning build flavour.
* Fixed and improved the apk bash script for parsing the device brand for when more then one result is found.

Signed-off-by: Exadra37 <exadra37@gmail.com>